### PR TITLE
refine init script

### DIFF
--- a/trojan/Makefile
+++ b/trojan/Makefile
@@ -4,6 +4,7 @@
 # This is free software, licensed under the GNU General Public License v3.
 # See /LICENSE for more information.
 #
+
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=trojan
@@ -73,13 +74,23 @@ endef
 
 
 define Package/trojan/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/trojan $(1)/usr/sbin/trojan
-	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_DATA) ./files/trojan.config $(1)/etc/config/trojan
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/trojan $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/trojan.init $(1)/etc/init.d/trojan
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/trojan/config.json $(1)/etc/trojan.json
+	$(INSTALL_BIN) files/trojan.init $(1)/etc/init.d/trojan
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) files/trojan.config $(1)/etc/config/trojan
+	$(INSTALL_DIR) $(1)/etc/trojan
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/examples/client.json-example $(1)/etc/trojan/client.json
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/examples/forward.json-example $(1)/etc/trojan/forward.json
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/examples/nat.json-example $(1)/etc/trojan/nat.json
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/examples/server.json-example $(1)/etc/trojan/server.json
+endef
+
+define Package/trojan/postrm
+#!/bin/sh
+rmdir --ignore-fail-on-non-empty /etc/trojan
+exit 0
 endef
 
 

--- a/trojan/files/trojan.config
+++ b/trojan/files/trojan.config
@@ -1,4 +1,5 @@
 
 config trojan
-	option enabled     '0'
+	option enable '0'
+	option config '/etc/trojan/client.json'
 

--- a/trojan/files/trojan.init
+++ b/trojan/files/trojan.init
@@ -1,37 +1,41 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2018 wongsyrone
 
-. /lib/functions.sh
-
 START=95
+
 USE_PROCD=1
 #PROCD_DEBUG=1
 
-PROG=/usr/sbin/trojan
-CONF=/etc/trojan.json
-
-config_load "trojan"
-
-parse_trojan() {
-	config_get ENABLED "$section" "enabled"
+append_param() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local default="$4"
+	local _loctmp
+	config_get _loctmp "$section" "$option"
+	[ -n "$_loctmp" -o -n "$default" ] || return 0
+	procd_append_param command "$switch" "${_loctmp:-$default}"
 }
 
-config_foreach parse_trojan 'trojan'
+start_trojan() {
+	local enable
+	config_get_bool enable $1 enable
+	[ "$enable" = 1 ] || return 0
 
+	procd_open_instance
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_set_param nice -5
+	procd_set_param limits nofile="1048576 1048576"
+	[ -e /proc/sys/kernel/core_pattern ] && {
+		procd_append_param limits core="unlimited"
+	}
+	procd_set_param command /usr/bin/trojan
+	append_param $1 config "-c"
+	procd_close_instance
+}
 
 start_service() {
-	if [ "1" = "$ENABLED" ] || [ "on" = "$ENABLED" ] || [ "true" = "$ENABLED" ]; then
-		procd_open_instance
-		procd_set_param command $PROG --config $CONF
-		procd_set_param user root # run service as user root
-		procd_set_param stdout 1 # forward stdout of the command to logd
-		procd_set_param stderr 1 # same for stderr
-		procd_set_param limits nofile="1048576 1048576" # max allowed value can be fetched via /proc/sys/fs/nr_open
-		[ -e /proc/sys/kernel/core_pattern ] && {
-			procd_append_param limits core="unlimited"
-		}
-		procd_close_instance
-	else
-		echo "trojan is disabled"
-	fi
+	config_load trojan
+	config_foreach start_trojan trojan
 }


### PR DESCRIPTION
改成看起来顺畅一点，参考 https://github.com/aa65535/openwrt-chinadns/blob/master/files/chinadns.init 这个脚本。

添加了 `config` 字段可以指定配置文件的位置。